### PR TITLE
feat: Add kube-prometheus-stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-dist/
-node_modules/
-

--- a/deploy/clusters/homelab/monitoring.yaml
+++ b/deploy/clusters/homelab/monitoring.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: monitoring-controllers
+  namespace: flux-system
+spec:
+  interval: 10m
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./deploy/monitoring/controllers/homelab
+
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+#---
+#apiVersion: kustomize.toolkit.fluxcd.io/v1
+#kind: Kustomization
+#metadata:
+#  name: monitoring-configs
+#  namespace: flux-system
+#spec:
+#  interval: 10m
+#  prune: true
+#  sourceRef:
+#    kind: GitRepository
+#    name: flux-system
+#  path: ./deploy/monitoring/configs/homelab
+#
+#  decryption:
+#    provider: sops
+#    secretRef:
+#      name: sops-age
+#  dependsOn:
+#    - name: flux-system
+#

--- a/deploy/infrastructure/homelab/tunnel.yaml
+++ b/deploy/infrastructure/homelab/tunnel.yaml
@@ -25,8 +25,6 @@ spec:
           - --config
           - /etc/cloudflared/config/config.yaml
           - run
-          - --protocol
-          - http2
           
           livenessProbe:
             httpGet:

--- a/deploy/monitoring/controllers/base/kube-prometheus-stack/kustomization.yaml
+++ b/deploy/monitoring/controllers/base/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml

--- a/deploy/monitoring/controllers/base/kube-prometheus-stack/namespace.yaml
+++ b/deploy/monitoring/controllers/base/kube-prometheus-stack/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring

--- a/deploy/monitoring/controllers/base/kube-prometheus-stack/release.yaml
+++ b/deploy/monitoring/controllers/base/kube-prometheus-stack/release.yaml
@@ -1,0 +1,26 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      version: "80.*"
+      sourceRef:
+        kind: HelmRepository
+        name: kube-prometheus-stack
+        namespace: monitoring
+      interval: 12h
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  driftDetection:
+    mode: enabled
+    ignore:
+      - paths: ["/metadata/annotations/prometheus-operator-validated"]
+        target:
+          kind: PrometheusRule

--- a/deploy/monitoring/controllers/base/kube-prometheus-stack/repository.yaml
+++ b/deploy/monitoring/controllers/base/kube-prometheus-stack/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+spec:
+  interval: 24h
+  url: https://prometheus-community.github.io/helm-charts

--- a/deploy/monitoring/controllers/homelab/kube-prometheus-stack/kustomization.yaml
+++ b/deploy/monitoring/controllers/homelab/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ../../base/kube-prometheus-stack/

--- a/deploy/monitoring/controllers/homelab/kustomization.yaml
+++ b/deploy/monitoring/controllers/homelab/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kube-prometheus-stack


### PR DESCRIPTION
## Pull request overview

This PR adds the kube-prometheus-stack monitoring solution to a homelab Kubernetes cluster using FluxCD for GitOps deployment. It establishes the monitoring infrastructure with Helm-based deployments and removes unrelated configuration files.

- Sets up kube-prometheus-stack using FluxCD HelmRelease with version constraint "80.*"
- Organizes monitoring resources using Kustomize with base/overlay pattern for environment-specific configurations
- Removes deprecated Cloudflare tunnel protocol flag and obsolete .dockerignore file